### PR TITLE
License added.

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,0 +1,1 @@
+This work is licensed under the Creative Commons Reconocimiento-CompartirIgual 4.0 Internacional License. To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/4.0/.


### PR DESCRIPTION
Been without an open license could set contributors back.
This is an example from http://choosealicense.com/ to be somehow like [wikipedia license](https://en.wikipedia.org/wiki/Wikipedia:Text_of_Creative_Commons_Attribution-ShareAlike_3.0_Unported_License). 
